### PR TITLE
Rename CV parts which got renamed

### DIFF
--- a/src/balance/balanceColor.cpp
+++ b/src/balance/balanceColor.cpp
@@ -49,7 +49,7 @@ void prl::colorBalance(const cv::Mat& inputImage, cv::Mat& outputImage,
 
     if (inputImage.channels() == 4)
     {
-        cv::cvtColor(imageCopy, imageCopy, CV_BGRA2BGR);
+        cv::cvtColor(imageCopy, imageCopy, cv::COLOR_BGRA2BGR);
     }
 
     std::vector<cv::Mat> srcChans(imageCopy.channels());
@@ -72,7 +72,7 @@ void prl::colorBalance(const cv::Mat& inputImage, cv::Mat& outputImage,
     {
         cv::Mat hsvImg;
 
-        cv::cvtColor(convertedTmp, hsvImg, CV_BGR2HSV);
+        cv::cvtColor(convertedTmp, hsvImg, cv::COLOR_BGR2HSV);
 
         cv::split(hsvImg, srcChans);
 
@@ -84,7 +84,7 @@ void prl::colorBalance(const cv::Mat& inputImage, cv::Mat& outputImage,
 
         cv::merge(srcChans, convertedTmp);
 
-        cv::cvtColor(convertedTmp, convertedTmp, CV_HSV2BGR);
+        cv::cvtColor(convertedTmp, convertedTmp, cv::COLOR_HSV2BGR);
     }
 
     outputImage = convertedTmp.clone();

--- a/src/balance/gammaCorrection.cpp
+++ b/src/balance/gammaCorrection.cpp
@@ -73,7 +73,7 @@ void gammaCorrection(const cv::Mat& inputImage, cv::Mat& outputImage,
 	//Converting to 3 channels
 	if (channels == 4)
 	{
-		cv::cvtColor(inputImageMat, outputImageMat, CV_BGRA2BGR);
+		cv::cvtColor(inputImageMat, outputImageMat, cv::COLOR_BGRA2BGR);
 	}
 
 	//Applying gamma correction

--- a/src/binarizations/binarizeAGT.cpp
+++ b/src/binarizations/binarizeAGT.cpp
@@ -47,7 +47,7 @@ void prl::binarizeAGT(const cv::Mat& inputImage, cv::Mat& outputImage, const int
 
     if (inputImageMat.channels() != 1)
     {
-        cv::cvtColor(tempOutputImageMat, outputImageMat, CV_BGR2GRAY);
+        cv::cvtColor(tempOutputImageMat, outputImageMat, cv::COLOR_BGR2GRAY);
     }
 
     cv::adaptiveThreshold(

--- a/src/binarizations/binarizeAT.cpp
+++ b/src/binarizations/binarizeAT.cpp
@@ -44,7 +44,7 @@ void prl::binarizeAT(const cv::Mat& inputImage, cv::Mat& outputImage, const int 
     {
         if (inputImageMat.channels() != 1)
         {
-            cv::cvtColor(inputImageMat, inputImageMat, CV_BGR2GRAY);
+            cv::cvtColor(inputImageMat, inputImageMat, cv::COLOR_BGR2GRAY);
         }
     }*/
 
@@ -55,7 +55,7 @@ void prl::binarizeAT(const cv::Mat& inputImage, cv::Mat& outputImage, const int 
 
     if (inputImageMat.channels() != 1)
     {
-        cv::cvtColor(tempOutputImageMat, outputImageMat, CV_BGR2GRAY);
+        cv::cvtColor(tempOutputImageMat, outputImageMat, cv::COLOR_BGR2GRAY);
     }
 
     cv::adaptiveThreshold(

--- a/src/binarizations/binarizeByLocalVariances.cpp
+++ b/src/binarizations/binarizeByLocalVariances.cpp
@@ -121,7 +121,7 @@ namespace prl
         cv::convertScaleAbs(varianceMapWithGammaCorrection, varianceMapWithGammaCorrection, 255.0, 0);
         //! Binarize
         cv::adaptiveThreshold(varianceMapWithGammaCorrection, varianceMapWithGammaCorrection,
-                              127.0, CV_ADAPTIVE_THRESH_MEAN_C, cv::THRESH_BINARY, 15, 0);
+                              127.0, cv::ADAPTIVE_THRESH_MEAN_C, cv::THRESH_BINARY, 15, 0);
 
         //! Try to extract noise for variance map in logarithmic scale
         cv::Mat noiseOfLogVarianceMap = varianceMapWithoutAdditionalProcessing.clone();

--- a/src/binarizations/binarizeCOCOCLUST.cpp
+++ b/src/binarizations/binarizeCOCOCLUST.cpp
@@ -67,7 +67,7 @@ void prl::binarizeCOCOCLUST(cv::Mat& inputImage, cv::Mat& outputImage, const flo
     //! Processing for gray scaled image
     if (inputImage.type() == CV_8UC3)
     {
-        cvtColor(inputImage, imageSelectedColorSpace, CV_RGB2GRAY);
+        cvtColor(inputImage, imageSelectedColorSpace, cv::COLOR_RGB2GRAY);
     }
     else
     {
@@ -103,7 +103,7 @@ void prl::binarizeCOCOCLUST(cv::Mat& inputImage, cv::Mat& outputImage, const flo
     //! We should have corresponding channels count for processing
     if (imageSelectedColorSpace.channels() != 3)
     {
-        cv::cvtColor(imageSelectedColorSpace, imageSelectedColorSpace, CV_GRAY2BGR);
+        cv::cvtColor(imageSelectedColorSpace, imageSelectedColorSpace, cv::COLOR_GRAY2BGR);
     }
 
     // Work copy of contours set
@@ -116,7 +116,7 @@ void prl::binarizeCOCOCLUST(cv::Mat& inputImage, cv::Mat& outputImage, const flo
         std::vector<cv::Vec4i> hierarchy;
 
         cv::findContours(resultCanny, contoursAll, hierarchy,
-                         CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
+                         cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
 
         contours = contoursAll;
 

--- a/src/binarizations/binarizeFBCITB.cpp
+++ b/src/binarizations/binarizeFBCITB.cpp
@@ -97,7 +97,7 @@ void prl::binarizeFBCITB(
     {
         if (inputImage.channels() == 1)
         {
-            cv::cvtColor(inputImage, inputImage, CV_GRAY2BGR);
+            cv::cvtColor(inputImage, inputImage, cv::COLOR_GRAY2BGR);
         }
         else
         {
@@ -199,14 +199,14 @@ void prl::binarizeFBCITB(
     //! contours detection
     if (useVariancesMap)
     {
-        cv::findContours(varianceMap, contours, hierarchy, CV_RETR_TREE,
-                         CV_CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
+        cv::findContours(varianceMap, contours, hierarchy, cv::RETR_TREE,
+                         cv::CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
     }
 
     if (isCannyRequired && !isVariancesMapRequired)
     {
-        cv::findContours(resultCanny, contours, hierarchy, CV_RETR_TREE,
-                         CV_CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
+        cv::findContours(resultCanny, contours, hierarchy, cv::RETR_TREE,
+                         cv::CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
     }
 
     if (contours.empty())
@@ -254,8 +254,8 @@ void prl::binarizeFBCITB(
 
     if (imageToProc.channels() == 3)
     {
-        cv::cvtColor(imageToProc, imageToProc, CV_BGR2GRAY);
-        cv::cvtColor(imageToProc, imageToProc, CV_GRAY2BGR);
+        cv::cvtColor(imageToProc, imageToProc, cv::COLOR_BGR2GRAY);
+        cv::cvtColor(imageToProc, imageToProc, cv::COLOR_GRAY2BGR);
     }
 
     cv::Mat resultImage(imageToProc.size(), CV_8UC1);

--- a/src/binarizations/binarizeFeng.cpp
+++ b/src/binarizations/binarizeFeng.cpp
@@ -50,7 +50,7 @@ void prl::binarizeFeng(
 
     if (inputImage.channels() != 1)
     {
-        cv::cvtColor(inputImage, inputImage, CV_BGR2GRAY);
+        cv::cvtColor(inputImage, inputImage, cv::COLOR_BGR2GRAY);
     }
 
     const int usedFloatType = CV_64FC1;

--- a/src/binarizations/binarizeGAT.cpp
+++ b/src/binarizations/binarizeGAT.cpp
@@ -43,7 +43,7 @@ void prl::binarizeGAT(const cv::Mat& inputImage, cv::Mat& outputImage, const int
 
     if (inputImageMat.channels() != 1)
     {
-        cv::cvtColor(inputImageMat, inputImageMat, CV_BGR2GRAY);
+        cv::cvtColor(inputImageMat, inputImageMat, cv::COLOR_BGR2GRAY);
     }
 
     cv::Mat outputImageMat;
@@ -55,7 +55,7 @@ void prl::binarizeGAT(const cv::Mat& inputImage, cv::Mat& outputImage, const int
 
     if (inputImageMat.channels() != 1)
     {
-        cv::cvtColor(tempOutputImageMat, outputImageMat, CV_BGR2GRAY);
+        cv::cvtColor(tempOutputImageMat, outputImageMat, cv::COLOR_BGR2GRAY);
     }
 
     cv::adaptiveThreshold(

--- a/src/binarizations/binarizeLocalOtsu.cpp
+++ b/src/binarizations/binarizeLocalOtsu.cpp
@@ -60,7 +60,7 @@ void prl::binarizeLocalOtsu(
     //! we work with gray image
     if (inputImage.channels() != 1)
     {
-        cv::cvtColor(inputImage, imageSelectedColorSpace, CV_RGB2GRAY);
+        cv::cvtColor(inputImage, imageSelectedColorSpace, cv::COLOR_RGB2GRAY);
     }
     else
     {
@@ -94,7 +94,7 @@ void prl::binarizeLocalOtsu(
 
     if (imageSelectedColorSpace.channels() != 3)
     {
-        cv::cvtColor(imageSelectedColorSpace, imageSelectedColorSpace, CV_GRAY2BGR);
+        cv::cvtColor(imageSelectedColorSpace, imageSelectedColorSpace, cv::COLOR_GRAY2BGR);
     }
 
     std::vector<std::vector<cv::Point>> contours;
@@ -104,8 +104,8 @@ void prl::binarizeLocalOtsu(
     {
         std::vector<cv::Vec4i> hierarchy;
 
-        cv::findContours(resultCanny, contoursAll, hierarchy, CV_RETR_EXTERNAL,
-                         CV_CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
+        cv::findContours(resultCanny, contoursAll, hierarchy, cv::RETR_EXTERNAL,
+                         cv::CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
 
         contours = contoursAll;
 
@@ -153,7 +153,7 @@ void prl::binarizeLocalOtsu(
             //! ... create copy and ...
             cv::Mat tmp = imageToProc(contourBoundingRectangle).clone();
             //! binarize it by Otsu
-            cv::threshold(tmp, tmp, 128, maxValue, CV_THRESH_OTSU);
+            cv::threshold(tmp, tmp, 128, maxValue, cv::THRESH_OTSU);
 
             //! Store binarization result to output image
             binarized(contourBoundingRectangle).setTo(0, tmp ^ 255);

--- a/src/binarizations/binarizeMokji.cpp
+++ b/src/binarizations/binarizeMokji.cpp
@@ -45,7 +45,7 @@ void binarizeMokji(const cv::Mat& inputImage, cv::Mat& outputImage,
     }
 
     cv::Mat gray;
-    cv::cvtColor(inputImage, gray, CV_BGR2GRAY);
+    cv::cvtColor(inputImage, gray, cv::COLOR_BGR2GRAY);
 
     const size_t dilateSize = (maxEdgeWidth + 1) * 2 - 1;
 
@@ -86,11 +86,11 @@ void binarizeMokji(const cv::Mat& inputImage, cv::Mat& outputImage,
 
     if (denominator == 0)
     {
-        cv::threshold(gray, outputImage, 128, 255, CV_THRESH_BINARY);
+        cv::threshold(gray, outputImage, 128, 255, cv::THRESH_BINARY);
     }
 
     const int threshold = 0.5 * nominator / denominator + 0.5;
-    cv::threshold(gray, outputImage, threshold, 255, CV_THRESH_BINARY);
+    cv::threshold(gray, outputImage, threshold, 255, cv::THRESH_BINARY);
 }
 
 }

--- a/src/binarizations/binarizeNICK.cpp
+++ b/src/binarizations/binarizeNICK.cpp
@@ -49,7 +49,7 @@ void prl::binarizeNICK(
 
     if (inputImage.channels() != 1)
     {
-        cv::cvtColor(inputImage, inputImage, CV_BGR2GRAY);
+        cv::cvtColor(inputImage, inputImage, cv::COLOR_BGR2GRAY);
     }
 
     const int usedFloatType = CV_64FC1;

--- a/src/binarizations/binarizeNativeAdaptive.cpp
+++ b/src/binarizations/binarizeNativeAdaptive.cpp
@@ -57,7 +57,7 @@ void prl::binarizeNativeAdaptive(
 
     if (inputImage.channels() > 1)
     {
-        cv::cvtColor(inputImage, inputImage, CV_BGR2GRAY);
+        cv::cvtColor(inputImage, inputImage, cv::COLOR_BGR2GRAY);
     }
 
     if (!isGaussianBlurReqiured)
@@ -75,11 +75,11 @@ void prl::binarizeNativeAdaptive(
     }
 
 
-    int adaptiveMethod = CV_ADAPTIVE_THRESH_MEAN_C;
+    int adaptiveMethod = cv::ADAPTIVE_THRESH_MEAN_C;
 
     if (isAdaptiveThresholdCalculatedByGaussian)
     {
-        adaptiveMethod = CV_ADAPTIVE_THRESH_GAUSSIAN_C;
+        adaptiveMethod = cv::ADAPTIVE_THRESH_GAUSSIAN_C;
     }
 
     std::vector<cv::Mat> inputImageChannels(outputImage.channels());

--- a/src/binarizations/binarizeNiblack.cpp
+++ b/src/binarizations/binarizeNiblack.cpp
@@ -48,7 +48,7 @@ void prl::binarizeNiblack(
 
     if (inputImage.channels() != 1)
     {
-        cv::cvtColor(inputImage, inputImage, CV_BGR2GRAY);
+        cv::cvtColor(inputImage, inputImage, cv::COLOR_BGR2GRAY);
     }
 
     const int usedFloatType = CV_64FC1;

--- a/src/binarizations/binarizePureAdaptive.cpp
+++ b/src/binarizations/binarizePureAdaptive.cpp
@@ -42,14 +42,14 @@ void prl::binarizePureAdaptive(const cv::Mat& inputImage, cv::Mat& outputImage,
 
     if (inputImageMat.channels() != 1)
     {
-        cv::cvtColor(inputImageMat, inputImageMat, CV_BGR2GRAY);
+        cv::cvtColor(inputImageMat, inputImageMat, cv::COLOR_BGR2GRAY);
     }
 
     cv::Mat outputImageMat;
 
     if (inputImageMat.channels() != 1)
     {
-        cv::cvtColor(inputImageMat, outputImageMat, CV_BGR2GRAY);
+        cv::cvtColor(inputImageMat, outputImageMat, cv::COLOR_BGR2GRAY);
     }
 
     cv::adaptiveThreshold(

--- a/src/binarizations/binarizePureAdaptiveGaussian.cpp
+++ b/src/binarizations/binarizePureAdaptiveGaussian.cpp
@@ -43,7 +43,7 @@ void prl::binarizePureAdaptiveGaussian(const cv::Mat& inputImage, cv::Mat& outpu
     {
         if (inputImageMat.channels() != 1)
         {
-            cv::cvtColor(inputImageMat, inputImageMat, CV_BGR2GRAY);
+            cv::cvtColor(inputImageMat, inputImageMat, cv::COLOR_BGR2GRAY);
         }
     }*/
 
@@ -51,7 +51,7 @@ void prl::binarizePureAdaptiveGaussian(const cv::Mat& inputImage, cv::Mat& outpu
 
     if (inputImageMat.channels() != 1)
     {
-        cv::cvtColor(inputImageMat, outputImageMat, CV_BGR2GRAY);
+        cv::cvtColor(inputImageMat, outputImageMat, cv::COLOR_BGR2GRAY);
     }
     /*else
     {

--- a/src/binarizations/binarizeSauvola.cpp
+++ b/src/binarizations/binarizeSauvola.cpp
@@ -48,7 +48,7 @@ void prl::binarizeSauvola(
 
     if (imageInput.channels() != 1)
     {
-        cv::cvtColor(imageInput, imageInput, CV_BGR2GRAY);
+        cv::cvtColor(imageInput, imageInput, cv::COLOR_BGR2GRAY);
     }
 
     const int usedFloatType = CV_64FC1;

--- a/src/binarizations/binarizeWolfJolion.cpp
+++ b/src/binarizations/binarizeWolfJolion.cpp
@@ -49,7 +49,7 @@ void prl::binarizeWolfJolion(
 
     if (imageInput.channels() != 1)
     {
-        cv::cvtColor(imageInput, imageInput, CV_BGR2GRAY);
+        cv::cvtColor(imageInput, imageInput, cv::COLOR_BGR2GRAY);
     }
 
     const int usedFloatType = CV_64FC1;

--- a/src/border_detection/autoCrop.cpp
+++ b/src/border_detection/autoCrop.cpp
@@ -142,7 +142,7 @@ bool autoCrop(cv::Mat& inputImage, cv::Mat& outputImage)
         case CV_8UC3:
             break;
         case CV_8UC1:
-            cv::cvtColor(inputImage, inputImage, CV_GRAY2BGR);
+            cv::cvtColor(inputImage, inputImage, cv::COLOR_GRAY2BGR);
             break;
         default:
             if (inputImage.empty())

--- a/src/border_detection/autoCropUtils.cpp
+++ b/src/border_detection/autoCropUtils.cpp
@@ -164,7 +164,7 @@ bool findDocumentContour(cv::Mat& source, std::vector<cv::Point2f>& resultContou
 
     cv::findContours(
             source.clone(), contours, hierarchy,
-            CV_RETR_CCOMP, CV_CHAIN_APPROX_SIMPLE,
+            cv::RETR_CCOMP, cv::CHAIN_APPROX_SIMPLE,
             cv::Point(0, 0));
 
     //! Approximate contours to polygons + get bounding rectangles and circles

--- a/src/deskew/deskew.cpp
+++ b/src/deskew/deskew.cpp
@@ -72,10 +72,10 @@ double prl::findOrientation(const cv::Mat& inputImage)
     cv::Mat grayImage;
     if(inputImage.channels() == 3)
     {
-        cv::cvtColor(inputImage, grayImage, CV_BGR2GRAY);
+        cv::cvtColor(inputImage, grayImage, cv::COLOR_BGR2GRAY);
     }
 
-    cv::adaptiveThreshold(grayImage, grayImage, 255, CV_ADAPTIVE_THRESH_MEAN_C, CV_THRESH_BINARY, 19, 9);
+    cv::adaptiveThreshold(grayImage, grayImage, 255, cv::ADAPTIVE_THRESH_MEAN_C, cv::THRESH_BINARY, 19, 9);
 
     PIX* pix = prl::opencvToLeptonica(&grayImage);
     if (!pix)
@@ -139,7 +139,7 @@ double prl::findOrientation(const cv::Mat& inputImage)
 double prl::findAngle(const cv::Mat& inputImage)
 {
     // AA: we need black-&-white image here even if none of threshold algorithms were called before
-    //cv::adaptiveThreshold(input, input, 255, CV_ADAPTIVE_THRESH_GAUSSIAN_C, CV_THRESH_BINARY, 15, 5);
+    //cv::adaptiveThreshold(input, input, 255, cv::ADAPTIVE_THRESH_GAUSSIAN_C, cv::THRESH_BINARY, 15, 5);
     cv::Mat input = inputImage.clone();
 
     cv::Size imgSize = input.size();
@@ -213,7 +213,7 @@ CV_EXPORTS bool prl::deskew(const cv::Mat& inputImage, cv::Mat& outputImage)
 
     if (inputImage.channels() != 1)
     {
-        cv::cvtColor(inputImage, processingImage, CV_BGR2GRAY);
+        cv::cvtColor(inputImage, processingImage, cv::COLOR_BGR2GRAY);
     }
     else
     {
@@ -221,7 +221,7 @@ CV_EXPORTS bool prl::deskew(const cv::Mat& inputImage, cv::Mat& outputImage)
     }
 
     //TODO: Should we use here another binarization algorithm?
-    cv::threshold(processingImage, processingImage, 128, 255, CV_THRESH_BINARY | CV_THRESH_OTSU);
+    cv::threshold(processingImage, processingImage, 128, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
 
     double angle = findAngle(processingImage);
 

--- a/src/formatConvert.cpp
+++ b/src/formatConvert.cpp
@@ -102,7 +102,7 @@ Pix* prl::opencvToLeptonica(const cv::Mat* inputImage)
             break;
 
         default:
-            CV_Error(CV_StsError, "Cannot convert RAW image to Pix\n");
+            CV_Error(cv::Error::StsError, "Cannot convert RAW image to Pix\n");
     }
     pixSetYRes(pix, 300);
     return pix;
@@ -129,7 +129,7 @@ cv::Mat prl::leptonicaToOpenCV(Pix* inputImage)
             type = CV_8UC3;
             break;
         default:
-            CV_Error(CV_StsError, "Cannot convert Pix image to cv::Mat\n");
+            CV_Error(cv::Error::StsError, "Cannot convert Pix image to cv::Mat\n");
             break;
     }
 
@@ -212,7 +212,7 @@ cv::Mat prl::leptonicaToOpenCV(Pix* inputImage)
             break;
 
         default:
-            CV_Error(CV_StsError, "Cannot convert Pix image to cv::Mat\n");
+            CV_Error(cv::Error::StsError, "Cannot convert Pix image to cv::Mat\n");
     }
 
     return mObj;

--- a/src/imageLibCommon.cpp
+++ b/src/imageLibCommon.cpp
@@ -293,7 +293,7 @@ void CannyEdgeDetection(cv::Mat& imageToProc, cv::Mat& resultCanny, int Gaussian
         //! 2. get Otsu threshold...
         cv::Mat tmp;
         double otsuThresholdValue = cv::threshold(channel, tmp, 0, 255,
-                                                  CV_THRESH_BINARY | CV_THRESH_OTSU);
+                                                  cv::THRESH_BINARY | cv::THRESH_OTSU);
 
         //! ... and calculate thresholds for ...
         double upperCoeff = CannyUpperThresholdCoeff;

--- a/src/imageLibCommon.h
+++ b/src/imageLibCommon.h
@@ -29,6 +29,7 @@
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc.hpp>
 
 /*!
  * \brief Get local variance map for OpenCV Mat.

--- a/src/removeDots.cpp
+++ b/src/removeDots.cpp
@@ -40,7 +40,7 @@ void prl::removeDots(const cv::Mat& inputImage, cv::Mat& outputImage, const doub
     cv::Mat gray;
     if (inputImage.channels() == 3)
     {
-        cv::cvtColor(inputImage, gray, CV_BGR2GRAY);
+        cv::cvtColor(inputImage, gray, cv::COLOR_BGR2GRAY);
     }
     else
     {
@@ -90,7 +90,7 @@ void prl::removeDots(const cv::Mat& inputImage, cv::Mat& outputImage, const doub
     // TODO: maybe we should find automatically background color and use it for filling instead of white
     /*for(const auto& keypoint : filteredKeypoints)
     {
-        cv::circle(outputImage, keypoint.pt, keypoint.size / 2.0 + 3, cv::Scalar(255,255,255), CV_FILLED);
+        cv::circle(outputImage, keypoint.pt, keypoint.size / 2.0 + 3, cv::Scalar(255,255,255), cv::FILLED);
     }*/
     cv::drawKeypoints(outputImage, keypoints, outputImage, cv::Scalar(0,0,255), cv::DrawMatchesFlags::DRAW_RICH_KEYPOINTS);
 }

--- a/src/removeHolePunch.cpp
+++ b/src/removeHolePunch.cpp
@@ -39,7 +39,7 @@ void prl::removeHolePunch(const cv::Mat& inputImage, cv::Mat& outputImage)
     cv::Mat gray;
     if (inputImage.channels() == 3)
     {
-        cv::cvtColor(inputImage, gray, CV_BGR2GRAY);
+        cv::cvtColor(inputImage, gray, cv::COLOR_BGR2GRAY);
     }
     else
     {
@@ -88,6 +88,6 @@ void prl::removeHolePunch(const cv::Mat& inputImage, cv::Mat& outputImage)
     // TODO: maybe we should find automatically background color and use it for filling instead of white
     for(const auto& keypoint : filteredKeypoints)
     {
-        cv::circle(outputImage, keypoint.pt, keypoint.size / 2.0 + 3, cv::Scalar(255,255,255), CV_FILLED);
+        cv::circle(outputImage, keypoint.pt, keypoint.size / 2.0 + 3, cv::Scalar(255,255,255), cv::FILLED);
     }
 }

--- a/src/removeLines.cpp
+++ b/src/removeLines.cpp
@@ -32,7 +32,7 @@ void prl::removeLines(const cv::Mat& inputImage, cv::Mat& outputImage)
     cv::Mat gray;
     if (inputImage.channels() == 3)
     {
-        cvtColor(inputImage, gray, CV_BGR2GRAY);
+        cvtColor(inputImage, gray, cv::COLOR_BGR2GRAY);
     }
     else
     {
@@ -41,8 +41,8 @@ void prl::removeLines(const cv::Mat& inputImage, cv::Mat& outputImage)
 
     cv::Mat bw;
     // TODO: Try to use another binarization here
-    //cv::adaptiveThreshold(gray, bw, 255, CV_ADAPTIVE_THRESH_MEAN_C, CV_THRESH_BINARY, 15, 0);
-    cv::threshold(~gray, bw, 255, 255, CV_THRESH_BINARY | CV_THRESH_OTSU);
+    //cv::adaptiveThreshold(gray, bw, 255, cv::ADAPTIVE_THRESH_MEAN_C, cv::THRESH_BINARY, 15, 0);
+    cv::threshold(~gray, bw, 255, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
 
     // Create the images that will use to extract the horizontal and vertical lines
     cv::Mat horizontal = bw.clone();

--- a/src/segmentation/segmentation_ccc.cpp
+++ b/src/segmentation/segmentation_ccc.cpp
@@ -30,7 +30,7 @@ namespace prl
             throw std::invalid_argument("Input image hasn't 3 channels.");
         }
         cv::Mat convImage;
-        cv::cvtColor(inputImage, convImage, CV_BGR2RGB);
+        cv::cvtColor(inputImage, convImage, cv::COLOR_BGR2RGB);
 
         int height, width;
         int i;
@@ -154,7 +154,7 @@ namespace prl
 
         outputImages.resize(3);
 
-        cv::threshold(outputImageBin, outputImageBin, 0, 255, CV_THRESH_BINARY | CV_THRESH_OTSU);
+        cv::threshold(outputImageBin, outputImageBin, 0, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
 
         outputImages[0] = outputImageBin.clone();
 

--- a/src/splitPage.cpp
+++ b/src/splitPage.cpp
@@ -36,7 +36,7 @@ std::pair<cv::Point, cv::Point> findVertLine(const cv::Mat &inputImage) {
 
     cv::Mat imageToProc = inputImage.clone();
     if (inputImage.channels() == 3) {
-        cv::cvtColor(inputImage, imageToProc, CV_BGR2GRAY);
+        cv::cvtColor(inputImage, imageToProc, cv::COLOR_BGR2GRAY);
     }
     // TODO: Should be possibly resized to smth like 256px
 

--- a/src/thinning/thinGuoHall.cpp
+++ b/src/thinning/thinGuoHall.cpp
@@ -78,7 +78,7 @@ void prl::thinGuoHall(cv::Mat& inputImage, cv::Mat& outputImage)
 
     if (imageUnderProcess.channels() == 3)
     {
-        cvtColor(imageUnderProcess, imageUnderProcess, CV_BGR2GRAY);
+        cvtColor(imageUnderProcess, imageUnderProcess, cv::COLOR_BGR2GRAY);
     }
 
     imageUnderProcess &= 1;

--- a/src/thinning/thinZhangSuen.cpp
+++ b/src/thinning/thinZhangSuen.cpp
@@ -79,7 +79,7 @@ void prl::thinZhangSuen(cv::Mat& inputImage, cv::Mat& outputImage)
 
     if (imageUnderProcess.channels() == 3)
     {
-        cv::cvtColor(imageUnderProcess, imageUnderProcess, CV_BGR2GRAY);
+        cv::cvtColor(imageUnderProcess, imageUnderProcess, cv::COLOR_BGR2GRAY);
     }
 
     imageUnderProcess &= 1;


### PR DESCRIPTION
Trying to build PRLib failed due to changes in the OpenCV API.
This commit contains the necessary changes to enable building
PRLib with OpenCV Version 4.1.1.